### PR TITLE
fix: pf-4530 unique signatures for zod

### DIFF
--- a/scripts/generate-zod-schemas.js
+++ b/scripts/generate-zod-schemas.js
@@ -9,11 +9,12 @@ const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, '..');
 
 // Create a hash signature from component props for duplicate detection
-function getPropsSignature(componentData) {
-  return (componentData.props || [])
+function getPropsSignature(componentName, componentData) {
+  const propsSig = (componentData.props || [])
     .map(p => `${p.name}:${p.type}`)
     .sort()
     .join('|');
+  return `${componentName}:${propsSig}`;
 }
 
 // Cache regexes for performance
@@ -280,7 +281,7 @@ function convertAllComponentsToZod(inputFile) {
   const { processedComponents, skippedCount } = Object.entries(metadata).reduce(
     (acc, [componentName, componentData]) => {
       // Generate signature for this component's props
-      const signature = getPropsSignature(componentData);
+      const signature = getPropsSignature(componentName, componentData);
       
       // Skip if empty (no props) or duplicate
       if (!signature || acc.seenSignatures.has(signature)) {


### PR DESCRIPTION
## What is it?
- fix: pf-4530 unique signatures for zod

## Notes
- The signature used to filter out zod generated schemas appeared to be patched after release of the initial work, attempting to regenerate the work without this patch removes valid zod schemas because a proceeding component could have the exact same props
- The zod generation script should be re-evaluated in general if we extend the maintenance cycle of this repo, this is only a patch to get it working in the short-term